### PR TITLE
Add html-proofer link/image checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,20 @@
+name: Check links
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  htmlproofer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Check internal links and images
+        run: bin/check-links

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@
 source "https://rubygems.org"
 
 gem 'jekyll'
+
+group :test do
+  gem 'html-proofer', '~> 5.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ gem 'jekyll'
 
 group :test do
   gem 'html-proofer', '~> 5.0'
+  # Pinned: html-proofer pulls in async, and 2.42.0 was yanked from RubyGems.
+  gem 'async', '2.41.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'jekyll'
 
 group :test do
   gem 'html-proofer', '~> 5.0'
-  # Pinned: html-proofer pulls in async, and 2.42.0 was yanked from RubyGems.
-  gem 'async', '2.41.0'
+  # Pinned: html-proofer pulls in async. The newest releases (2.41.0, 2.42.0)
+  # resolve inconsistently on CI's RubyGems edge; 2.40.0 is stable everywhere.
+  gem 'async', '2.40.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
-    async (2.42.0)
+    async (2.41.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -133,6 +133,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  async (= 2.41.0)
   html-proofer (~> 5.0)
   jekyll
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,55 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.42.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
+    console (1.37.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
     eventmachine (1.2.7)
     ffi (1.16.3)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (3.25.3-arm64-darwin)
     google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
+    hashery (2.1.2)
+    html-proofer (5.2.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-event (1.19.2)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -37,6 +70,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.21.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -45,16 +79,33 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
+    metrics (0.15.0)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (5.0.4)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.3.6)
       strscan
     rouge (4.2.0)
+    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.71.1-arm64-darwin)
       google-protobuf (~> 3.25)
@@ -65,8 +116,15 @@ GEM
     strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    traces (0.18.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
+    yell (2.2.2)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   arm64-darwin-23
@@ -75,6 +133,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  html-proofer (~> 5.0)
   jekyll
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
-    async (2.41.0)
+    async (2.40.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -49,7 +49,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-event (1.19.2)
+    io-event (1.19.3)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -133,7 +133,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  async (= 2.41.0)
+  async (= 2.40.0)
   html-proofer (~> 5.0)
   jekyll
 

--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -9,7 +9,7 @@
 <ul class="entry-tags">
   {% for tag in sorted_tags %}
     <li>
-      <a href="/tags/#{{ tag }}" title="Pages tagged {{ tag }}">#{{ tag }}</a>
+      <a href="/tags/#{{ tag }}" title="Pages tagged {{ tag }}"><span class="tag-hash">#</span>{{ tag }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,6 @@
         {% else %}
           <h1 class="entry-title">{% if page.headline %}{{ page.headline }}{% else %}{{ page.title }}{% endif %}</h1>
         {% endif %}
-        {% include tags.html %}
       </header>
       <footer class="entry-meta">
         {% if page.author %}
@@ -36,6 +35,12 @@
         <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
         {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
         {% if site.owner.comment-address and page.comments != false %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="mailto:{{site.owner.comment-address}}">Comment</a></span>{% endif %}
+        {% if page.tags %}
+          <div class="entry-tags-wrap">
+            <p class="entry-tags-heading">Tagged</p>
+            {% include tags.html %}
+          </div>
+        {% endif %}
         {% if page.ads == true %}{% include ad-sidebar.html %}<!-- /.google-ads -->{% endif %}
       </footer>
       <div class="entry-content">

--- a/_posts/2006-03-03-auto-previewable-wicket-pages.md
+++ b/_posts/2006-03-03-auto-previewable-wicket-pages.md
@@ -45,7 +45,7 @@ Here's a quick demo of how it looks now!
 
 
 
-The wicket-preview.js is pretty simple. It uses [dojo](http://dojotoolkit.org/) in the same way as my previous demo, and uses the [Behaviour javascript library](bennolan.com/behaviour/) to automatically parse out the wicket:preview attribute and swap in the included file contents. The implementation is maybe a bit basic, but that can be improved later. It seems like the majority of included components use a div tag, but it probably should support the span tag as well.
+The wicket-preview.js is pretty simple. It uses [dojo](http://dojotoolkit.org/) in the same way as my previous demo, and uses the [Behaviour javascript library](http://bennolan.com/behaviour/) to automatically parse out the wicket:preview attribute and swap in the included file contents. The implementation is maybe a bit basic, but that can be improved later. It seems like the majority of included components use a div tag, but it probably should support the span tag as well.
 
 
 ```javascript

--- a/_posts/2008-08-27-delicious-ubiquity-command_27.md
+++ b/_posts/2008-08-27-delicious-ubiquity-command_27.md
@@ -22,7 +22,7 @@ I've published my Ubiquity command on [github](http://www.github.com), and hopef
 
 
 
-You can download the command directly from github at [http://gist.github.com/7516](http://gist.github.com/7516%20) or just copy this command into your command editor. Ubiquity can also auto-detect changes to the latest version if you subscribe to the command using [this link](http://gist.github.com/7516.txt).
+You can download the command directly from github at [http://gist.github.com/7516](http://gist.github.com/7516) or just copy this command into your command editor. Ubiquity can also auto-detect changes to the latest version if you subscribe to the command using [this link](http://gist.github.com/7516.txt).
 
 
 

--- a/_posts/2008-12-22-fork-it-up-assert-valid-markup_22.md
+++ b/_posts/2008-12-22-fork-it-up-assert-valid-markup_22.md
@@ -54,7 +54,7 @@ _no such file to load -- FileUtils
 /home/eventrobot/.cruise/projects/socialcast/work/vendor/plugins/assert\_valid\_markup/lib/assert\_valid\_markup.rb:5
 
 /usr/local/lib/ruby/site\_ruby/1.8/rubygems/custom\_require.rb:27:in `gem\_original\_require' _
-After digging through the plugin source code, I did what any inquisitive developer would do, **FORK IT UP**! [A small change](http://github.com/wireframe/assert_valid_markup/commit/637088fbd8ff8d1d507a8d07403ca92e04b9a684%20%20) to the plugin and I was back up and running...almost.  Another issue cropped up when running the tests through Cruisecontrol.
+After digging through the plugin source code, I did what any inquisitive developer would do, **FORK IT UP**! [A small change](http://github.com/wireframe/assert_valid_markup/commit/637088fbd8ff8d1d507a8d07403ca92e04b9a684) to the plugin and I was back up and running...almost.  Another issue cropped up when running the tests through Cruisecontrol.
 
 _/usr/local/bin/ruby -Ilib:test
 
@@ -93,7 +93,7 @@ from
 
 from ./vendor/plugins/ez-where/test/test\_helper.rb:6 _
 
-Tracking down this issue was a real pain.  I spend the majority of my afternoon banging my head against the wall, but [I eventually tracked it down](http://github.com/wireframe/assert_valid_markup/commit/5883b603b5cf6381fc75364756d496f30c886cdf%20%20).  Tests are now up and running, and I have a github project with all of my fixes available for anyone to check out.  I'm still not 100% clear on the differences between my local environment and cruisecontrol, but that's for another time.
+Tracking down this issue was a real pain.  I spend the majority of my afternoon banging my head against the wall, but [I eventually tracked it down](http://github.com/wireframe/assert_valid_markup/commit/5883b603b5cf6381fc75364756d496f30c886cdf).  Tests are now up and running, and I have a github project with all of my fixes available for anyone to check out.  I'm still not 100% clear on the differences between my local environment and cruisecontrol, but that's for another time.
 
 I may take this fork a bit further and turn it into a ruby gem instead of a rails plugin.  It seems better suited that way now that I ripped out the rails initializer code.
 

--- a/_posts/2009-01-09-quest-for-correct-content-types_09.md
+++ b/_posts/2009-01-09-quest-for-correct-content-types_09.md
@@ -7,16 +7,16 @@ tags:
  - ruby
 ---
 
-[Attachment Fu is a kick ass rails plugin](http://github.com/technoweenie/attachment_fu/tree/master%20) for handling file uploads within your rails application.  It greatly simplifies the ordeal of supporting file uploads and even supports some really amazing features like using Amazon S3 as a backend to store your files.  My only gripes thus far have been finicky thumbnail generation...
+[Attachment Fu is a kick ass rails plugin](http://github.com/technoweenie/attachment_fu/tree/master) for handling file uploads within your rails application.  It greatly simplifies the ordeal of supporting file uploads and even supports some really amazing features like using Amazon S3 as a backend to store your files.  My only gripes thus far have been finicky thumbnail generation...
 
 
 _**And**_correct detection of the file content type...
 
 
-I'm using a [flash widget for file uploads](http://developer.yahoo.com/yui/uploader/%20) in my app and it's been a pretty good solution except for the fact that flash kind of "forgets" to send the file content type to the server. _Oooppps_!  You see, browsers are responsible for including the content type when they post the file to the server and not having the correct content type causes all sorts of funky issues when the file is downloaded.  For example, a MS Word document will open with the wrong application if you don't have the correct content type.
+I'm using a [flash widget for file uploads](http://developer.yahoo.com/yui/uploader/) in my app and it's been a pretty good solution except for the fact that flash kind of "forgets" to send the file content type to the server. _Oooppps_!  You see, browsers are responsible for including the content type when they post the file to the server and not having the correct content type causes all sorts of funky issues when the file is downloaded.  For example, a MS Word document will open with the wrong application if you don't have the correct content type.
 
 
-Since [web browsers are not exactly any more trustworthy than flash](http://swfupload.org/forum/generaldiscussion/166%20)_*cough* IE *cough*_, it would be prudent to have the server do it's best to detect and/or correct the mime type sent by the client browser.  This led me to create [a fork of the attachment\_fu project](http://github.com/wireframe/attachment_fu%20) and improve the support for determining content types if/when the browser was unable to do so.
+Since [web browsers are not exactly any more trustworthy than flash](http://swfupload.org/forum/generaldiscussion/166)_*cough* IE *cough*_, it would be prudent to have the server do it's best to detect and/or correct the mime type sent by the client browser.  This led me to create [a fork of the attachment\_fu project](http://github.com/wireframe/attachment_fu) and improve the support for determining content types if/when the browser was unable to do so.
 
 
 My solution is to determine the file content type by checking a chain of different mime type decision points.  First and foremost, the content type from the browser is used if available. If one is not given, or if the browser is unable to determine the content type, a series of fallback implementations try to reconcile the issue.
@@ -25,7 +25,7 @@ My solution is to determine the file content type by checking a chain of differe
 The first fallback is to rely on the file extension to lookup the mime type.  This is a very simple and flexible solution that allows for easy addition/customization of accepted mime types. Registering new mime types in rails is a snap, and this solution was necessary for me to support the new ms office 2007 document types.
 
 
-Using the unix 'file' command to detect the content type is the next fallback.  This solution inspects the contents of the file to determine the file type.  It works relatively well except for when file contents are not necessarily unique.  For example, [all ms-office documents are reported as application/msword due to the file contents being nearly identical](http://www.mediawiki.org/wiki/Manual_talk:Mime_type_detection%20).
+Using the unix 'file' command to detect the content type is the next fallback.  This solution inspects the contents of the file to determine the file type.  It works relatively well except for when file contents are not necessarily unique.  For example, [all ms-office documents are reported as application/msword due to the file contents being nearly identical](http://www.mediawiki.org/wiki/Manual_talk:Mime_type_detection).
 
 
 If all else fails, we simply set the content type to "application/octet-stream" which basically means "unknown binary data".

--- a/_posts/2011-11-28-callbackskipper-for-faster-factories.md
+++ b/_posts/2011-11-28-callbackskipper-for-faster-factories.md
@@ -53,7 +53,7 @@ end
 
 Oh yes, we _can_ have our cake and eat it too...
 
-The callback\_skipper gem is equivalent to the core [ActiveRecord.skip\_callback](https://github.com/wireframe/callback_skipperhttp://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-skip_callback) method with the added benefit of only skipping the callback for a specific instance instead of globally for all invocations.
+The callback\_skipper gem is equivalent to the core [ActiveRecord.skip\_callback](http://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-skip_callback) method with the added benefit of only skipping the callback for a specific instance instead of globally for all invocations.
 
 As always, the gem is 100% opensource and suggestions are welcome!
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -395,6 +395,36 @@ body {
   }
 }
 
+// Post sidebar tags: quiet, muted, stacked under a "Tagged" label
+.entry-tags-wrap {
+  margin-top: 16px;
+}
+.entry-tags-heading {
+  @include font-size(11, no, 1);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  color: lighten($black, 60%);
+  margin: 0 0 6px;
+}
+.entry-meta .entry-tags {
+  letter-spacing: 0.03em;
+  font-weight: 400;
+  margin-bottom: 0;
+  li {
+    @include font-size(12, no, 1);
+    display: block;
+    margin: 0;
+    padding: 6px 0;
+  }
+  a {
+    color: lighten($black, 50%);
+    .tag-hash {
+      color: lighten($black, 68%);
+    }
+  }
+}
+
 ul.posts {
   li {
     list-style: none;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -397,25 +397,37 @@ body {
 
 // Post sidebar tags: quiet, muted, stacked under a "Tagged" label
 .entry-tags-wrap {
-  margin-top: 16px;
+  margin-top: 0;
+  @include media($large) {
+    margin-top: 16px;
+  }
 }
 .entry-tags-heading {
+  display: none;
   @include font-size(11, no, 1);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   font-weight: 700;
   color: lighten($black, 60%);
   margin: 0 0 6px;
+  @include media($large) {
+    display: block;
+  }
 }
 .entry-meta .entry-tags {
   letter-spacing: 0.03em;
   font-weight: 400;
-  margin-bottom: 0;
+  margin: 0;
   li {
     @include font-size(12, no, 1);
-    display: block;
-    margin: 0;
-    padding: 6px 0;
+    display: inline-block;
+    margin: 0 12px 0 0;
+    padding: 2px 0;
+    @include media($large) {
+      display: block;
+      margin: 0;
+      padding: 6px 0;
+    }
   }
   a {
     color: lighten($black, 50%);

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -523,7 +523,7 @@ span + .entry-title {
 }
 .entry-content {
   @include span-columns(12);
-  p:first-child {
+  > :first-child {
     margin-top: 0;
   }
   @include media($large) {

--- a/bin/check-links
+++ b/bin/check-links
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Build the site and validate its links and images with html-proofer.
+#
+# Usage:
+#   bin/check-links              # internal links + images only (fast)
+#   bin/check-links --external   # also validate outbound URLs (slow, flaky on old posts)
+#
+# HTTPS is not enforced and missing alt text is ignored on purpose: this blog
+# has 20 years of legacy http:// links, and the goal here is finding links and
+# images that are actually broken, not modernizing every historical URL.
+
+set -e
+
+EXTERNAL="--disable-external"
+if [ "$1" = "--external" ]; then
+  # Old posts point at plenty of sites that now rate-limit or block bots.
+  # Ignore the status codes those return rather than the links themselves.
+  EXTERNAL="--ignore-status-codes 0,403,429,500,503,999"
+fi
+
+bundle exec jekyll build --trace
+
+bundle exec htmlproofer ./_site \
+  --checks Links,Images \
+  --no-enforce-https \
+  --ignore-missing-alt \
+  --ignore-empty-alt \
+  $EXTERNAL


### PR DESCRIPTION
Adds automated link/image validation for the blog.

## What's here
- **`bin/check-links`** — builds the site and validates links + images with [html-proofer](https://github.com/gjtorikian/html-proofer). Internal-only by default (~2s over 294 files); `bin/check-links --external` also validates outbound URLs.
- **`.github/workflows/link-check.yml`** — runs `bin/check-links` on every PR.
- **`Gemfile`** — adds `html-proofer ~> 5.0` in a `:test` group.
- **One link fix** — `2006-03-03-auto-previewable-wicket-pages.md` had a `Behaviour library` link missing its `http://` scheme, so it resolved as a broken internal path. The checker caught it.

## Notes
HTTPS enforcement and alt-text checks are disabled on purpose. With them on, html-proofer flagged ~1,228 "failures" that were almost entirely 20-year-old `http://` links being dinged for not being HTTPS. Off, it surfaces genuinely broken links/images — which is the point.

Run `bin/check-links --external` when you want to triage the legacy empty-image links from old posts (dead Flickr/Blogspot URLs) with real data.