### PR TITLE
Fix mobile page title shrinking below content headings

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -425,10 +425,10 @@ span + .entry-title {
   margin-top: 10px;
   font-family: $alt-font;
   font-style: italic;
-  @include font-size(36,yes,36);
+  @include font-size(44,yes,44);
   font-weight: 400;
   line-height: 1;
-  letter-spacing: -3px;
+  letter-spacing: -0.04em;
   a {
     color: $black;
     text-decoration: underline;


### PR DESCRIPTION
## Problem
On mobile, the page title (`.entry-title`) looked *smaller* than the `h2`/`h3` headings within the post body — an inverted hierarchy.

## Root cause
The title and content headings are sized by separate systems that only agree on desktop:
- `.entry-title` scales responsively: 68px → 52px → **36px floor on mobile**.
- Content headings are fixed at all widths (`h1` 36, `h2` 32, `h3` 28) and render **bold sans-serif**, while the title is **normal-weight italic serif**.

So on mobile the title collapses to 36px — equal to `h1`, barely above `h2`/`h3` — and its lighter italic serif reads smaller than the bold content headings. A fixed `letter-spacing: -3px` also over-tightened the title at small sizes (−8% per char at 36px vs −4% at 68px).

## Fix
- Raise the mobile floor from `font-size(36)` to `font-size(44)` so the title stays clearly above content headings on phones. Desktop steps (52/68px) unchanged.
- Replace `letter-spacing: -3px` with proportional `-0.04em` so tracking scales with size instead of crushing small text.

Verified in the compiled `main.css`: mobile `.entry-title` now renders `44px` / `letter-spacing: -0.04em`.