### PR TITLE
Clean up malformed URLs in legacy posts

### DIFF
--- a/_posts/2006-03-03-auto-previewable-wicket-pages.md
+++ b/_posts/2006-03-03-auto-previewable-wicket-pages.md
@@ -45,7 +45,7 @@ Here's a quick demo of how it looks now!
 
 
 
-The wicket-preview.js is pretty simple. It uses [dojo](http://dojotoolkit.org/) in the same way as my previous demo, and uses the [Behaviour javascript library](bennolan.com/behaviour/) to automatically parse out the wicket:preview attribute and swap in the included file contents. The implementation is maybe a bit basic, but that can be improved later. It seems like the majority of included components use a div tag, but it probably should support the span tag as well.
+The wicket-preview.js is pretty simple. It uses [dojo](http://dojotoolkit.org/) in the same way as my previous demo, and uses the [Behaviour javascript library](http://bennolan.com/behaviour/) to automatically parse out the wicket:preview attribute and swap in the included file contents. The implementation is maybe a bit basic, but that can be improved later. It seems like the majority of included components use a div tag, but it probably should support the span tag as well.
 
 
 ```javascript

--- a/_posts/2008-08-27-delicious-ubiquity-command_27.md
+++ b/_posts/2008-08-27-delicious-ubiquity-command_27.md
@@ -22,7 +22,7 @@ I've published my Ubiquity command on [github](http://www.github.com), and hopef
 
 
 
-You can download the command directly from github at [http://gist.github.com/7516](http://gist.github.com/7516%20) or just copy this command into your command editor. Ubiquity can also auto-detect changes to the latest version if you subscribe to the command using [this link](http://gist.github.com/7516.txt).
+You can download the command directly from github at [http://gist.github.com/7516](http://gist.github.com/7516) or just copy this command into your command editor. Ubiquity can also auto-detect changes to the latest version if you subscribe to the command using [this link](http://gist.github.com/7516.txt).
 
 
 

--- a/_posts/2008-12-22-fork-it-up-assert-valid-markup_22.md
+++ b/_posts/2008-12-22-fork-it-up-assert-valid-markup_22.md
@@ -54,7 +54,7 @@ _no such file to load -- FileUtils
 /home/eventrobot/.cruise/projects/socialcast/work/vendor/plugins/assert\_valid\_markup/lib/assert\_valid\_markup.rb:5
 
 /usr/local/lib/ruby/site\_ruby/1.8/rubygems/custom\_require.rb:27:in `gem\_original\_require' _
-After digging through the plugin source code, I did what any inquisitive developer would do, **FORK IT UP**! [A small change](http://github.com/wireframe/assert_valid_markup/commit/637088fbd8ff8d1d507a8d07403ca92e04b9a684%20%20) to the plugin and I was back up and running...almost.  Another issue cropped up when running the tests through Cruisecontrol.
+After digging through the plugin source code, I did what any inquisitive developer would do, **FORK IT UP**! [A small change](http://github.com/wireframe/assert_valid_markup/commit/637088fbd8ff8d1d507a8d07403ca92e04b9a684) to the plugin and I was back up and running...almost.  Another issue cropped up when running the tests through Cruisecontrol.
 
 _/usr/local/bin/ruby -Ilib:test
 
@@ -93,7 +93,7 @@ from
 
 from ./vendor/plugins/ez-where/test/test\_helper.rb:6 _
 
-Tracking down this issue was a real pain.  I spend the majority of my afternoon banging my head against the wall, but [I eventually tracked it down](http://github.com/wireframe/assert_valid_markup/commit/5883b603b5cf6381fc75364756d496f30c886cdf%20%20).  Tests are now up and running, and I have a github project with all of my fixes available for anyone to check out.  I'm still not 100% clear on the differences between my local environment and cruisecontrol, but that's for another time.
+Tracking down this issue was a real pain.  I spend the majority of my afternoon banging my head against the wall, but [I eventually tracked it down](http://github.com/wireframe/assert_valid_markup/commit/5883b603b5cf6381fc75364756d496f30c886cdf).  Tests are now up and running, and I have a github project with all of my fixes available for anyone to check out.  I'm still not 100% clear on the differences between my local environment and cruisecontrol, but that's for another time.
 
 I may take this fork a bit further and turn it into a ruby gem instead of a rails plugin.  It seems better suited that way now that I ripped out the rails initializer code.
 

--- a/_posts/2009-01-09-quest-for-correct-content-types_09.md
+++ b/_posts/2009-01-09-quest-for-correct-content-types_09.md
@@ -7,16 +7,16 @@ tags:
  - ruby
 ---
 
-[Attachment Fu is a kick ass rails plugin](http://github.com/technoweenie/attachment_fu/tree/master%20) for handling file uploads within your rails application.  It greatly simplifies the ordeal of supporting file uploads and even supports some really amazing features like using Amazon S3 as a backend to store your files.  My only gripes thus far have been finicky thumbnail generation...
+[Attachment Fu is a kick ass rails plugin](http://github.com/technoweenie/attachment_fu/tree/master) for handling file uploads within your rails application.  It greatly simplifies the ordeal of supporting file uploads and even supports some really amazing features like using Amazon S3 as a backend to store your files.  My only gripes thus far have been finicky thumbnail generation...
 
 
 _**And**_correct detection of the file content type...
 
 
-I'm using a [flash widget for file uploads](http://developer.yahoo.com/yui/uploader/%20) in my app and it's been a pretty good solution except for the fact that flash kind of "forgets" to send the file content type to the server. _Oooppps_!  You see, browsers are responsible for including the content type when they post the file to the server and not having the correct content type causes all sorts of funky issues when the file is downloaded.  For example, a MS Word document will open with the wrong application if you don't have the correct content type.
+I'm using a [flash widget for file uploads](http://developer.yahoo.com/yui/uploader/) in my app and it's been a pretty good solution except for the fact that flash kind of "forgets" to send the file content type to the server. _Oooppps_!  You see, browsers are responsible for including the content type when they post the file to the server and not having the correct content type causes all sorts of funky issues when the file is downloaded.  For example, a MS Word document will open with the wrong application if you don't have the correct content type.
 
 
-Since [web browsers are not exactly any more trustworthy than flash](http://swfupload.org/forum/generaldiscussion/166%20)_*cough* IE *cough*_, it would be prudent to have the server do it's best to detect and/or correct the mime type sent by the client browser.  This led me to create [a fork of the attachment\_fu project](http://github.com/wireframe/attachment_fu%20) and improve the support for determining content types if/when the browser was unable to do so.
+Since [web browsers are not exactly any more trustworthy than flash](http://swfupload.org/forum/generaldiscussion/166)_*cough* IE *cough*_, it would be prudent to have the server do it's best to detect and/or correct the mime type sent by the client browser.  This led me to create [a fork of the attachment\_fu project](http://github.com/wireframe/attachment_fu) and improve the support for determining content types if/when the browser was unable to do so.
 
 
 My solution is to determine the file content type by checking a chain of different mime type decision points.  First and foremost, the content type from the browser is used if available. If one is not given, or if the browser is unable to determine the content type, a series of fallback implementations try to reconcile the issue.
@@ -25,7 +25,7 @@ My solution is to determine the file content type by checking a chain of differe
 The first fallback is to rely on the file extension to lookup the mime type.  This is a very simple and flexible solution that allows for easy addition/customization of accepted mime types. Registering new mime types in rails is a snap, and this solution was necessary for me to support the new ms office 2007 document types.
 
 
-Using the unix 'file' command to detect the content type is the next fallback.  This solution inspects the contents of the file to determine the file type.  It works relatively well except for when file contents are not necessarily unique.  For example, [all ms-office documents are reported as application/msword due to the file contents being nearly identical](http://www.mediawiki.org/wiki/Manual_talk:Mime_type_detection%20).
+Using the unix 'file' command to detect the content type is the next fallback.  This solution inspects the contents of the file to determine the file type.  It works relatively well except for when file contents are not necessarily unique.  For example, [all ms-office documents are reported as application/msword due to the file contents being nearly identical](http://www.mediawiki.org/wiki/Manual_talk:Mime_type_detection).
 
 
 If all else fails, we simply set the content type to "application/octet-stream" which basically means "unknown binary data".

--- a/_posts/2011-11-28-callbackskipper-for-faster-factories.md
+++ b/_posts/2011-11-28-callbackskipper-for-faster-factories.md
@@ -53,7 +53,7 @@ end
 
 Oh yes, we _can_ have our cake and eat it too...
 
-The callback\_skipper gem is equivalent to the core [ActiveRecord.skip\_callback](https://github.com/wireframe/callback_skipperhttp://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-skip_callback) method with the added benefit of only skipping the callback for a specific instance instead of globally for all invocations.
+The callback\_skipper gem is equivalent to the core [ActiveRecord.skip\_callback](http://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-skip_callback) method with the added benefit of only skipping the callback for a specific instance instead of globally for all invocations.
 
 As always, the gem is 100% opensource and suggestions are welcome!
 


### PR DESCRIPTION
Strips trailing `%20` (encoded spaces) that leaked into several link URLs during migration, and adds a missing `http://` scheme, so the links resolve correctly.

Affected posts: 2006-03-03, 2008-08-27, 2008-12-22, 2009-01-09, 2011-11-28.

One of these (the Behaviour library link) is the broken link surfaced by the link-checker in the related PRs.