### PR TITLE
Rework post tag placement and mobile layout

### DIFF
--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -9,7 +9,7 @@
 <ul class="entry-tags">
   {% for tag in sorted_tags %}
     <li>
-      <a href="/tags/#{{ tag }}" title="Pages tagged {{ tag }}">#{{ tag }}</a>
+      <a href="/tags/#{{ tag }}" title="Pages tagged {{ tag }}"><span class="tag-hash">#</span>{{ tag }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,6 @@
         {% else %}
           <h1 class="entry-title">{% if page.headline %}{{ page.headline }}{% else %}{{ page.title }}{% endif %}</h1>
         {% endif %}
-        {% include tags.html %}
       </header>
       <footer class="entry-meta">
         {% if page.author %}
@@ -36,6 +35,12 @@
         <span class="entry-date date published"><time datetime="{{ page.date | date_to_xmlschema }}"><i class="fa fa-calendar-o"></i> {{ page.date | date: "%B %d, %Y" }}</time></span>
         {% if page.modified %}<span class="entry-date date modified"><time datetime="{{ page.modified }}"><i class="fa fa-pencil"></i> {{ page.modified | date: "%B %d, %Y" }}</time></span>{% endif %}
         {% if site.owner.comment-address and page.comments != false %}<span class="entry-comments"><i class="fa fa-comment-o"></i> <a href="mailto:{{site.owner.comment-address}}">Comment</a></span>{% endif %}
+        {% if page.tags %}
+          <div class="entry-tags-wrap">
+            <p class="entry-tags-heading">Tagged</p>
+            {% include tags.html %}
+          </div>
+        {% endif %}
         {% if page.ads == true %}{% include ad-sidebar.html %}<!-- /.google-ads -->{% endif %}
       </footer>
       <div class="entry-content">

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -395,6 +395,36 @@ body {
   }
 }
 
+// Post sidebar tags: quiet, muted, stacked under a "Tagged" label
+.entry-tags-wrap {
+  margin-top: 16px;
+}
+.entry-tags-heading {
+  @include font-size(11, no, 1);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  color: lighten($black, 60%);
+  margin: 0 0 6px;
+}
+.entry-meta .entry-tags {
+  letter-spacing: 0.03em;
+  font-weight: 400;
+  margin-bottom: 0;
+  li {
+    @include font-size(12, no, 1);
+    display: block;
+    margin: 0;
+    padding: 6px 0;
+  }
+  a {
+    color: lighten($black, 50%);
+    .tag-hash {
+      color: lighten($black, 68%);
+    }
+  }
+}
+
 ul.posts {
   li {
     list-style: none;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -397,25 +397,37 @@ body {
 
 // Post sidebar tags: quiet, muted, stacked under a "Tagged" label
 .entry-tags-wrap {
-  margin-top: 16px;
+  margin-top: 0;
+  @include media($large) {
+    margin-top: 16px;
+  }
 }
 .entry-tags-heading {
+  display: none;
   @include font-size(11, no, 1);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   font-weight: 700;
   color: lighten($black, 60%);
   margin: 0 0 6px;
+  @include media($large) {
+    display: block;
+  }
 }
 .entry-meta .entry-tags {
   letter-spacing: 0.03em;
   font-weight: 400;
-  margin-bottom: 0;
+  margin: 0;
   li {
     @include font-size(12, no, 1);
-    display: block;
-    margin: 0;
-    padding: 6px 0;
+    display: inline-block;
+    margin: 0 12px 0 0;
+    padding: 2px 0;
+    @include media($large) {
+      display: block;
+      margin: 0;
+      padding: 6px 0;
+    }
   }
   a {
     color: lighten($black, 50%);

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -523,7 +523,7 @@ span + .entry-title {
 }
 .entry-content {
   @include span-columns(12);
-  p:first-child {
+  > :first-child {
     margin-top: 0;
   }
   @include media($large) {


### PR DESCRIPTION
Layout changes for post tags and content spacing:
- Move the tags block and adjust `_layouts/post.html` / `_includes/tags.html`
- Tighten the tag layout on mobile
- Remove the top margin on the first content element