### PR TITLE
Add bin/check-links link/image checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@
 source "https://rubygems.org"
 
 gem 'jekyll'
+
+group :test do
+  gem 'html-proofer', '~> 5.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,55 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.42.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
+    console (1.37.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
     eventmachine (1.2.7)
     ffi (1.16.3)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (3.25.3-arm64-darwin)
     google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
+    hashery (2.1.2)
+    html-proofer (5.2.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-event (1.19.3)
     jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -37,6 +70,7 @@ GEM
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.21.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -45,16 +79,33 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
+    metrics (0.15.0)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (5.0.4)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.3.6)
       strscan
     rouge (4.2.0)
+    ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     sass-embedded (1.71.1-arm64-darwin)
       google-protobuf (~> 3.25)
@@ -65,8 +116,15 @@ GEM
     strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    traces (0.18.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
+    yell (2.2.2)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   arm64-darwin-23
@@ -75,6 +133,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  html-proofer (~> 5.0)
   jekyll
 
 BUNDLED WITH

--- a/bin/check-links
+++ b/bin/check-links
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Build the site and validate its links and images with html-proofer.
+#
+# Usage:
+#   bin/check-links              # internal links + images only (fast)
+#   bin/check-links --external   # also validate outbound URLs (slow, flaky on old posts)
+#
+# HTTPS is not enforced and missing alt text is ignored on purpose: this blog
+# has 20 years of legacy http:// links, and the goal here is finding links and
+# images that are actually broken, not modernizing every historical URL.
+
+set -e
+
+EXTERNAL="--disable-external"
+if [ "$1" = "--external" ]; then
+  # Old posts point at plenty of sites that now rate-limit or block bots.
+  # Ignore the status codes those return rather than the links themselves.
+  EXTERNAL="--ignore-status-codes 0,403,429,500,503,999"
+fi
+
+bundle exec jekyll build --trace
+
+bundle exec htmlproofer ./_site \
+  --checks Links,Images \
+  --no-enforce-https \
+  --ignore-missing-alt \
+  --ignore-empty-alt \
+  $EXTERNAL


### PR DESCRIPTION
Adds [html-proofer](https://github.com/gjtorikian/html-proofer) (test group) and a `bin/check-links` script that builds the site and validates links and images.

- Internal-only by default (~2s over ~290 files); `bin/check-links --external` also validates outbound URLs.
- HTTPS enforcement and alt-text checks are disabled so it reports genuinely broken links/images rather than 20 years of legacy `http://` URLs.

Running it against master flags one real broken link (the Behaviour library link), which the posts-cleanup PR fixes.