### PR TITLE
Run link-check in CI on pull requests

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,20 @@
+name: Check links
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  htmlproofer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Check internal links and images
+        run: bin/check-links


### PR DESCRIPTION
Adds a workflow that builds the site and runs `bin/check-links` on every PR. **Stacked on the link-check-cli PR** (needs `bin/check-links` + html-proofer).

⚠️ Known issue: CI `bundle install` currently fails on a GitHub-runner-side RubyGems resolution problem (the runner's index reports `async` as removed, though it installs fine everywhere else — GitHub and RubyGems both report operational, and a clean frozen install succeeds locally). This is external and not fixable from the repo by version pinning. Merge once the runner environment recovers, or hold this PR while using `bin/check-links` locally.