### PR TITLE
Use mise to provision Ruby in the deploy workflow

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -33,13 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
-        with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+      - name: Install gems
+        run: bundle install
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Switches the Pages deploy build from `ruby/setup-ruby` to `jdx/mise-action`, provisioning Ruby from `.mise.toml` (matching local dev and the link-check workflow).

This also **unbreaks deploys**: master's Gemfile now includes html-proofer, whose `async` dependency requires Ruby >= 3.3, so `bundle install` failed on the previous hardcoded Ruby 3.1 (the deploy has been red since the CLI PR merged).