### PR TITLE
Use Jekyll {% post_url %} for internal post links

### DIFF
--- a/_posts/2026-04-10-team-topology-ownership.md
+++ b/_posts/2026-04-10-team-topology-ownership.md
@@ -32,7 +32,7 @@ But where do you draw the lines? This is a great opportunity to partner with pro
 
 **Split systems that move at different speeds.** Parts of the system that change weekly don't belong in the same team as parts that change quarterly. Splitting by change cadence lets each part move at its natural pace.
 
-**Keep maintenance and innovation together.** I've seen organizations split teams into "build the new thing" and "keep the lights on," and it creates a two-tiered class system of innovators and maintainers. The team that builds a system should own it through its full lifecycle: building, running, and improving it. I wrote about this in my [Greenhouse post](https://www.codecrate.com/2026/02/the-greenhouse-innovation-incubator.html), specifically about the anti-pattern of incubating in one team and handing off to another for "productionization." You can't outsource expertise. No one will know your customer, your data, or your activation funnels better than the team that built it.
+**Keep maintenance and innovation together.** I've seen organizations split teams into "build the new thing" and "keep the lights on," and it creates a two-tiered class system of innovators and maintainers. The team that builds a system should own it through its full lifecycle: building, running, and improving it. I wrote about this in my [Greenhouse post]({% post_url 2026-02-05-the-greenhouse-innovation-incubator %}), specifically about the anti-pattern of incubating in one team and handing off to another for "productionization." You can't outsource expertise. No one will know your customer, your data, or your activation funnels better than the team that built it.
 
 ## Constantly Reorganize to Win -- But Thoughtfully
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -3,5 +3,4 @@
 - fix broken markdwon underline syntax.  e.g. Performance is overrated
 - use markdown image syntax to get alt text.  is there a jekyll plugin i should use instead?
 - cleanup any unnecessary html content in posts.
-- are there any links to posts that i should be using jekyll for?
 - should the home page 'how i work' section link to any of my posts by tag, or to specific posts?  (e.g. leadership/culture/etc)


### PR DESCRIPTION
## What

Converts the one hardcoded internal post link in `_posts/2026-04-10-team-topology-ownership.md` to Jekyll's `{% post_url %}` tag.

Before:
```
[Greenhouse post](https://www.codecrate.com/2026/02/the-greenhouse-innovation-incubator.html)
```
After:
```
[Greenhouse post]({% post_url 2026-02-05-the-greenhouse-innovation-incubator %})
```

Also removes the completed item from `docs/backlog.md`.

## Why

- Portability: the URL stays correct if the permalink structure ever changes.
- Fails loudly: if the target post is removed, the Jekyll build errors instead of silently shipping a dead link.

## Scope

Only real internal links to this blog's own posts were converted. The 3 dead external `codecrate.com` links elsewhere (snipsnap wiki, shard app) are defunct services, not posts, and were intentionally left alone.

`grep -rnE "https?://(www\.)?codecrate\.com/[0-9]{4}/[0-9]{2}/" _posts/` confirms the Greenhouse link was the only internal post link.

## Verification

`bin/check-links` passes: Jekyll build succeeds and htmlproofer validates all 449 internal links with no errors.