### PR TITLE
Convert img tags to markdown image syntax with alt text

### DIFF
--- a/_posts/2014-05-22-day-one-rails-continuous-integration.md
+++ b/_posts/2014-05-22-day-one-rails-continuous-integration.md
@@ -25,7 +25,7 @@ as many checks and balances necessary to feel confident that you are releasing
 good code**.
 
 <p class="text-center">
-<img src="/images/automate_all_the_things.jpg" alt="Automate all the Things"/>
+![Automate all the Things](/images/automate_all_the_things.jpg)
 </p>
 
 ## The Basics (Test suite)

--- a/_posts/2014-10-01-bundler-updater-gem.md
+++ b/_posts/2014-10-01-bundler-updater-gem.md
@@ -6,7 +6,7 @@ tags:
 ---
 
 <p class="text-center">
-<img alt="If you bundle update your entire Gemfile, you're going to have a bad time." src="/images/bundle_update_bad_time.jpg" />
+![If you bundle update your entire Gemfile, you're going to have a bad time.](/images/bundle_update_bad_time.jpg)
 </p>
 
 On any reasonably sized production project, you should **absolutely never** update all outdated gems at once.

--- a/_posts/2023-11-23-my-no-shame-november-story.md
+++ b/_posts/2023-11-23-my-no-shame-november-story.md
@@ -16,7 +16,7 @@ I had one particular user who was vocal when things came up. In one particular i
 
 After multiple rapid-fire back-and-forth emails to try and resolve this issue as quickly as possible and get back to "cranking out __L33T__ code", I took a screenshot of the screen that she was referring to, imported it into Microsoft Paint, and using a bright red pencil, circled the part of the page that had the feature she needed, and sent my last email to her with no text. Just the image. It looked like a six-year-old had scribbled on the page to highlight the area.  A bit like this...
 
-<img src="/images/2023-11-23.png" alt="Oh the humanity..."/>
+![Oh the humanity...](/images/2023-11-23.png)
 
 A few minutes later, I had my "oh shit" realization. This wasn't user error. It was a legit bug that I wasn't reproducing locally. I can remember sinking down into my cubicle in shame realizing that this was 100% my fault. Fixing the bug took minutes, and I honestly can't remember if I ever responded back to that member owning up to my mistake.
 

--- a/_posts/2024-04-13-the-commit-cycle.md
+++ b/_posts/2024-04-13-the-commit-cycle.md
@@ -13,7 +13,7 @@ Since then, I've had the opportunity to be a part of multiple Zero to one startu
 
 Time is the enemy of every startup, and the best way to increase our odds of success is by having our customers tell us what matters to them as quickly as possible (and what doesn't matter). The tighter our feedback loops, the more opportunities we have to iterate and get it right for our customers. I've taken a few concepts that have been useful for me and refined them into a Product Development Process (PDP) called "The Commit Cycle".
 
-<img src="/images/the_commit_cycle.png">
+![The Commit Cycle: a continuous loop from Align to Execute to Evaluate](/images/the_commit_cycle.png)
 
 First, we need to know where we are headed. **We commit to a *direction*.**
 

--- a/_posts/2025-03-12-team-topology-graph-visualizer.md
+++ b/_posts/2025-03-12-team-topology-graph-visualizer.md
@@ -9,7 +9,7 @@ Over the past 10 years of scaling engineering teams, one of the most critical ti
 
 The framework introduced in [Team Topologies: Organizing Business and Technology Teams for Fast Flow](https://www.amazon.com/Team-Topologies-Organizing-Business-Technology-ebook/dp/B09JWT9S4D) does a fantastic job of capturing these essential elements of team formations and has been my go-to book recommendation for other engineering leaders over the years.
 
-<img src="/images/2025-03-12-legend.png">
+![Team Topologies legend showing the four team types and three interaction modes](/images/2025-03-12-legend.png)
 
 The visualization format used in the book is fairly effective for laying out the team formations, but after putting it into real-world usage with a fairly large organization (100+ engineers and 15+ teams), I ran into a few specific shortcomings:
 
@@ -19,6 +19,6 @@ The visualization format used in the book is fairly effective for laying out the
 
 After some ideation and experimentation, I found visualization via a graph network to hit the sweet spot to showcase the full spectrum of teams + interactions + amount of investment in each team.
 
-<img src="/images/2025-03-12-graph.png">
+![Team topology rendered as a network graph, with nodes colored by team type and sized by headcount, connected by labeled interaction edges](/images/2025-03-12-graph.png)
 
 With just an hour hacking away (thanks to rapid prototyping support via [Cursor](https://www.cursor.com/)), I was able to whip up a proof of concept app that "scratched my itch" and is extensible to support any permutation of teams via a simple JSON configuration. [The code is 100% opensource](https://github.com/wireframe/team-topology-graph), and if you're interested to give it a run, I welcome any feedback for improvements!

--- a/_posts/2025-04-28-the-most-powerful-part-of-your-product-roadmap.md
+++ b/_posts/2025-04-28-the-most-powerful-part-of-your-product-roadmap.md
@@ -11,7 +11,7 @@ I came away with a new insight after a cross-functional review of my team's stra
 
 While I’m a big believer in outcome-based roadmaps, output-based roadmaps have an important place, especially when it comes to sequencing work across cross-functional teams.  To help increase the level of clarity and alignment across teams, I added an **explicit** section to my [team's V2OOO strategy]({% post_url 2025-02-04-v2ooo %}) for what we are not doing (ie: "The Not Doing List").
 
-<img src="/images/2025-04-28.png" width="50%" />
+<img src="/images/2025-04-28.png" width="50%" alt="A handwritten product roadmap listing planned features above a separate Not Doing List" />
 
 Why was this so effective?  I believe there are three distinct reasons.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,6 @@
 # Backlog
 
 - fix broken markdwon underline syntax.  e.g. Performance is overrated
-- use markdown image syntax to get alt text.  is there a jekyll plugin i should use instead?
 - cleanup any unnecessary html content in posts.
 - are there any links to posts that i should be using jekyll for?
 - should the home page 'how i work' section link to any of my posts by tag, or to specific posts?  (e.g. leadership/culture/etc)


### PR DESCRIPTION
Converts inline `<img>` tags to markdown image syntax and ensures every image has alt text.

## Owner's question: is there a Jekyll plugin for alt text?
No. No Jekyll plugin auto-generates alt text — it describes image content, which has to be authored per-image. The alt text below was written by hand for each image.

## Converted to markdown `![alt](src)`
These tags had only `src` (and sometimes `alt`), so markdown covers them fully:

- `2014-05-22-day-one-rails-continuous-integration.md` — kept existing alt "Automate all the Things"
- `2023-11-23-my-no-shame-november-story.md` — kept existing alt "Oh the humanity..."
- `2014-10-01-bundler-updater-gem.md` — kept existing alt "If you bundle update your entire Gemfile, you're going to have a bad time."
- `2024-04-13-the-commit-cycle.md` — no alt before; drafted "The Commit Cycle: a continuous loop from Align to Execute to Evaluate"
- `2025-03-12-team-topology-graph-visualizer.md` (2 images) — no alt before; drafted "Team Topologies legend showing the four team types and three interaction modes" and "Team topology rendered as a network graph, with nodes colored by team type and sized by headcount, connected by labeled interaction edges"

## Kept as HTML (with alt added)
- `2025-04-28-the-most-powerful-part-of-your-product-roadmap.md` — uses `width="50%"`, which markdown cannot express. Kept the tag and its width, added alt "A handwritten product roadmap listing planned features above a separate Not Doing List"

## Backlog
Removed the now-resolved backlog line.

## Verification
`bin/check-links` passes (Jekyll build + html-proofer Links/Images, 294 files, no broken images or links).
