### PR TITLE
Full system fonts, no external loader (modern header redesign)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,8 +24,6 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="/assets/css/main.css">
-<!-- Webfonts -->
-<script src="//use.edgefonts.net/source-sans-pro:n2,i2,n3,i3,n4,i4,n6,i6,n7,i7,n9,i9;source-code-pro:n4,n7;volkhov.js"></script>
 
 <meta http-equiv="cleartype" content="on">
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -465,12 +465,11 @@ span + .entry-title {
 }
 .entry-title {
   margin-top: 10px;
-  font-family: $alt-font;
-  font-style: italic;
-  @include font-size(44,yes,44);
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.04em;
+  font-family: $heading-font;
+  @include font-size(44,yes,46);
+  font-weight: 300;
+  line-height: 1.03;
+  letter-spacing: -0.03em;
   a {
     color: $black;
     text-decoration: underline;
@@ -479,7 +478,7 @@ span + .entry-title {
     @include font-size(52,yes,54);
   }
   @include media($large) {
-    @include font-size(68,yes,72);
+    @include font-size(64,yes,66);
   }
 }
 .entry-wrapper {

--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -44,6 +44,8 @@ li {
 // Headings
 h1, h2, h3, h4, h5, h6 {
 	font-family: $heading-font;
+	font-weight: 500;
+	letter-spacing: -0.022em;
 	text-rendering: optimizeLegibility; // Fix the character spacing for headings
 }
 h1 {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,6 +1,7 @@
 // TYPOGRAPHY ================================================
+$system-font: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, sans-serif;
 $base-font: 'source-sans-pro', sans-serif;
-$heading-font: $base-font;
+$heading-font: $system-font;
 $caption-font: $base-font;
 $code-font: 'source-code-pro', monospace;
 $alt-font: 'volkhov', serif;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,10 +1,10 @@
 // TYPOGRAPHY ================================================
 $system-font: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, sans-serif;
-$base-font: 'source-sans-pro', sans-serif;
+$base-font: $system-font;
 $heading-font: $system-font;
 $caption-font: $base-font;
-$code-font: 'source-code-pro', monospace;
-$alt-font: 'volkhov', serif;
+$code-font: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+$alt-font: ui-serif, 'New York', Georgia, serif;
 
 $doc-font-size: 16;
 $doc-line-height: 24;


### PR DESCRIPTION
Moves the whole site to system fonts and removes the external edgefonts loader. Started as a header-only redesign ("Light Keynote"), now extended to body + code so there's no third-party font download at all.

## What changed

**Headers (commit 1)**
- New `\$system-font` stack (`-apple-system` → SF Pro on Apple, graceful sans fallbacks elsewhere); `\$heading-font` points at it.
- Headings (h1–h6): weight 500, `-0.022em` tracking.
- Post titles: system sans, weight **300**, tight tracking (was volkhov italic serif).

**Full system fonts + loader removal (commit 2)**
- `\$base-font`: system sans (was source-sans-pro) — body copy.
- `\$code-font`: `ui-monospace` / SF Mono (was source-code-pro).
- `\$alt-font`: `ui-serif` → New York on Apple, Georgia elsewhere (was volkhov). Keeps the serif accent on the bio statement + blockquotes, no download.
- Removed the `//use.edgefonts.net` `<script>` from `head.html`.

## Why
- Modern/thin, narrower-letterform direction (Apple's current styling).
- Eliminates a render-blocking third-party request — all type now paints instantly from system fonts.

## Testing
- `bundle exec jekyll build` compiles clean.
- Compiled `main.css` has zero `source-sans-pro` / `volkhov` / `source-code-pro` references; built `index.html` has no edgefonts loader.
- Reviewer to test locally (`bundle exec jekyll serve`): homepage + a post, code blocks, blockquotes, light/dark.

## Notes
- `\$alt-font` stays serif so the bio statement ("I build products...") and blockquotes keep editorial contrast. If you'd rather go fully sans there too, that's a one-line follow-up.
- `.entry-title` link still uses `text-decoration: underline`; worth eyeballing under weight 300.