### PR TITLE
Point site.url at the canonical www host

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-codecrate.com
+www.codecrate.com

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ search: true
 # The url is only used when full-domain names are needed
 # such as sitemap and atom
 # Most places will/should use BASE_PATH to make the urls
-url: https://codecrate.com
+url: https://www.codecrate.com
 locale: en_US
 image:
   feature: background.jpg

--- a/resume.md
+++ b/resume.md
@@ -5,7 +5,7 @@ description: "Chief Technology Officer — building stuff that matters."
 ---
 
 *Chief Technology Officer • "Building stuff that matters."*
-Minneapolis, Minnesota (50% on-site) • [ryan.sonnek@gmail.com](mailto:ryan.sonnek@gmail.com) • [linkedin.com/in/ryansonnek](https://linkedin.com/in/ryansonnek) • [codecrate.com](https://codecrate.com)
+Minneapolis, Minnesota (50% on-site) • [ryan.sonnek@gmail.com](mailto:ryan.sonnek@gmail.com) • [linkedin.com/in/ryansonnek](https://linkedin.com/in/ryansonnek) • [codecrate.com](https://www.codecrate.com)
 
 
 ---


### PR DESCRIPTION
Follow-up to #31. Found while verifying that PR's deploy.

## Problem

GitHub Pages serves `www.codecrate.com` (confirmed via the Pages API custom domain setting) and 301s the apex to it. But `_config.yml` had `url: https://codecrate.com`, so every absolute URL the site generates pointed at a redirect: `canonical`, `og:url`, `og:image`, `twitter:image`, and the atom feed.

Previews still worked through the 301, but LinkedIn is picky when `og:url` disagrees with the URL it fetched.

Two smaller things surfaced with it:

- `CNAME` said `codecrate.com`, disagreeing with the Pages custom domain. It never mattered because `_config.yml` excludes `CNAME` from the build so the file is never published, but leaving it wrong is a trap for whoever removes that exclude.
- `resume.md` linked the apex on line 8 and www on line 69.

## Changes

- `_config.yml`: `url: https://www.codecrate.com`
- `CNAME`: match the Pages custom domain
- `resume.md`: use www in the header link, matching the one further down

## Verification

Zero apex URLs left in the build, down from 300 pages' worth:

```
$ grep -rho 'https://codecrate\.com' _site --include='*.html' --include='*.xml' | wc -l
0

$ bin/check-social-preview
All pages have complete social preview metadata

$ bin/check-links
Ran on 300 files!
HTML-Proofer finished successfully.
```

## Heads up

`atom.xml` derives its feed id and entry ids from `site.url`, so those all change. Some feed readers key on entry id and may re-surface existing posts as unread once. That is the cost of moving to the canonical host, and it only happens on this one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)